### PR TITLE
Disable Game_Login_Overlay when AutoLogin disabled

### DIFF
--- a/projects/Launcher/Windows/Launcher.xaml.cs
+++ b/projects/Launcher/Windows/Launcher.xaml.cs
@@ -241,9 +241,12 @@ namespace Forgotten_Land_Launcher
 
                     Game_Handler.StartDiscordRPCUpdater();
 
-                    Game_Login_Overlay game_Login = new Game_Login_Overlay();
+                    if (Launcher_Settings.AutoLogin)
+                    {
+                        Game_Login_Overlay game_Login = new Game_Login_Overlay();
 
-                    game_Login.Show();
+                        game_Login.Show();
+                    }
 
                     btnPlay.Content = "PLAY";
                     btnPlay.IsEnabled = true;


### PR DESCRIPTION
## Summary
- avoid showing `Game_Login_Overlay` by default
- only show the overlay if `Launcher_Settings.AutoLogin` is true

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506fdce1648323beb7cf90d0f6f120